### PR TITLE
feat: add basic auth logic by email with JWT

### DIFF
--- a/client/src/entities/session/api/sessionApi.tsx
+++ b/client/src/entities/session/api/sessionApi.tsx
@@ -1,0 +1,48 @@
+import { mapSession } from 'src/entities/session/lib/mapSession'
+import { baseApi } from 'src/shared/api'
+import { config } from 'src/shared/config'
+import { type Session, type RequestLoginBody, type SessionDto, User } from 'src/entities/session/api/types'
+import { mapUser } from 'src/entities/session/lib/mapUser'
+
+const keyLS = `${config.PREFIX}:refresh_token`
+
+export const sessionApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    refresh: build.query<Session, void>({
+      query: () => ({
+        url: `/auth/v1/token?grant_type=refresh_token`,
+        method: 'GET',
+        body: {
+          refresh_token: window.localStorage.getItem(keyLS)
+        },
+        headers: {
+          apikey: config.API_KEY
+        }
+      }),
+      transformResponse: (response: SessionDto) => mapSession(response)
+    }),
+    signup: build.mutation({
+      query: (body: RequestLoginBody) => ({
+        url: `/auth/v1/signup`,
+        method: 'POST',
+        body,
+        headers: {
+          apikey: config.API_KEY
+        }
+      })
+    }),
+    login: build.mutation<User, RequestLoginBody>({
+      query: (body) => ({
+        url: `/auth/v1/token?grant_type=password`,
+        method: 'POST',
+        body,
+        headers: {
+          apikey: config.API_KEY
+        }
+      }),
+      transformResponse: (response: SessionDto) => mapUser(response)
+    })
+  })
+})
+
+export const { useRefreshQuery, useSignupMutation, useLoginMutation } = sessionApi

--- a/client/src/entities/session/api/types.ts
+++ b/client/src/entities/session/api/types.ts
@@ -1,0 +1,59 @@
+export interface SessionDto {
+  access_token: string
+  token_type: string
+  expires_in: number
+  refresh_token: string
+  user: UserDto
+}
+
+export interface UserDto {
+  id: string
+  aud: string
+  role: string
+  email: string
+  email_confirmed_at: string
+  phone: string
+  confirmation_sent_at: string
+  confirmed_at: string
+  last_sign_in_at: string
+  app_metadata: AppMetadata
+  user_metadata: UserMetadata
+  identities?: IdentitiesEntity[] | null
+  created_at: string
+  updated_at: string
+}
+export interface AppMetadata {
+  provider: string
+  providers?: string[] | null
+}
+export type UserMetadata = Record<string, unknown>
+export interface IdentitiesEntity {
+  id: string
+  user_id: string
+  identity_data: IdentityData
+  provider: string
+  last_sign_in_at: string
+  created_at: string
+  updated_at: string
+}
+export interface IdentityData {
+  email: string
+  sub: string
+}
+
+export type SessionUserId = Brand<Id, 'SessionUserId'>
+
+export type Session = {
+  accessToken: string
+  userId: SessionUserId
+}
+
+export type User = {
+  email: string
+  userId: SessionUserId
+}
+
+export type RequestLoginBody = {
+  email: string
+  password: string
+}

--- a/client/src/entities/session/index.tsx
+++ b/client/src/entities/session/index.tsx
@@ -1,0 +1,1 @@
+export { sessionSlice } from './model/slice'

--- a/client/src/entities/session/lib/mapSession.ts
+++ b/client/src/entities/session/lib/mapSession.ts
@@ -1,0 +1,8 @@
+import { type SessionUserId, type Session, type SessionDto } from 'src/entities/session/api/types'
+
+export function mapSession(dto: SessionDto): Session {
+  return {
+    accessToken: dto.access_token,
+    userId: dto.user.id as SessionUserId
+  }
+}

--- a/client/src/entities/session/lib/mapUser.ts
+++ b/client/src/entities/session/lib/mapUser.ts
@@ -1,0 +1,8 @@
+import { type SessionUserId, type User, type SessionDto } from 'src/entities/session/api/types'
+
+export function mapUser(dto: SessionDto): User {
+  return {
+    email: dto.user.email,
+    userId: dto.user.id as SessionUserId
+  }
+}

--- a/client/src/entities/session/model/slice.ts
+++ b/client/src/entities/session/model/slice.ts
@@ -1,0 +1,68 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { SessionUserId } from 'src/entities/session/api/types'
+import { sessionApi } from 'src/entities/session/api/sessionApi'
+import { getRegisterStatusThunk } from 'src/features/authentication/signin/model'
+
+type SessionSliceState = {
+  isLoading: boolean
+  email: string
+} & SessionState
+
+type SessionState =
+  | {
+      accessToken: string
+      userId: SessionUserId
+      isAuthorized: true
+    }
+  | {
+      isAuthorized: false
+      accessToken?: string
+      userId?: SessionUserId
+    }
+
+const initialState: SessionSliceState = {
+  isAuthorized: false,
+  isLoading: true,
+  email: ''
+}
+
+export const sessionSlice = createSlice({
+  name: 'session',
+  initialState,
+  reducers: {
+    clearSessionData: (state) => {
+      state.accessToken = undefined
+      state.userId = undefined
+      state.isAuthorized = false
+      state.email = ''
+    },
+    setUserEmail: (state, { payload }) => {
+      state.email = payload
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getRegisterStatusThunk.fulfilled, (state: SessionSliceState, { payload }) => {
+      if (payload) {
+        state.isLoading = false
+        state.isAuthorized = true
+        state.email = payload?.email
+      } else {
+        state.isLoading = false
+        state.isAuthorized = false
+      }
+    })
+    builder.addCase(getRegisterStatusThunk.pending, (state: SessionSliceState) => {
+      state.isLoading = true
+    })
+    builder.addMatcher(sessionApi.endpoints.login.matchFulfilled, (state: SessionSliceState, { payload }) => {
+      state.isAuthorized = true
+      if (state.isAuthorized) {
+        state.userId = payload.userId
+        state.isLoading = false
+        state.email = payload.email
+      }
+    })
+  }
+})
+
+export const { clearSessionData, setUserEmail } = sessionSlice.actions

--- a/client/src/entities/viewer/model/index.tsx
+++ b/client/src/entities/viewer/model/index.tsx
@@ -1,0 +1,1 @@
+export * as selectors from './selectors'

--- a/client/src/entities/viewer/model/selectors.ts
+++ b/client/src/entities/viewer/model/selectors.ts
@@ -1,0 +1,14 @@
+import { useSelector } from 'react-redux'
+import type { RootState } from 'src/app/store/types'
+
+export const useViewer = () => {
+  return useSelector((state: RootState) => state.session)
+}
+
+export const useAuth = () => {
+  const { email } = useViewer()
+  return {
+    isAuth: !!email,
+    email
+  }
+}

--- a/client/src/entities/viewer/ui/card/index.tsx
+++ b/client/src/entities/viewer/ui/card/index.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable */
+import React from 'react'
+import { EditOutlined, EllipsisOutlined, SettingOutlined } from '@ant-design/icons'
+import { Avatar, Card } from 'antd'
+
+const { Meta } = Card
+
+type User = {
+  bio: string
+  fullName: string
+}
+
+export type UserCardProps = {
+  data: User
+  className?: string
+}
+
+export const ViewerCard = ({ data, className }: UserCardProps) => {
+  return (
+    <Card
+      hoverable
+      title={data.fullName}
+      cover={<img alt="example" />}
+      actions={[
+        <SettingOutlined key="setting" />,
+        <EditOutlined key="edit" />,
+        <EllipsisOutlined key="ellipsis" />
+      ]}
+    >
+      <Meta avatar={<Avatar src="https://" />} title="Card title" description="This is the description" />
+    </Card>
+  )
+}

--- a/client/src/entities/viewer/ui/index.tsx
+++ b/client/src/entities/viewer/ui/index.tsx
@@ -1,0 +1,1 @@
+export { ViewerCard } from './card'

--- a/client/src/features/authentication/by-google/Actions/index.ts
+++ b/client/src/features/authentication/by-google/Actions/index.ts
@@ -1,0 +1,1 @@
+export * as Actions from './model'

--- a/client/src/features/authentication/by-google/Actions/model.ts
+++ b/client/src/features/authentication/by-google/Actions/model.ts
@@ -1,0 +1,16 @@
+import { supabase } from 'src/app/supabase'
+
+export async function signInWithGoogle() {
+  try {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google'
+    })
+    if (error) {
+      throw new Error(error.message)
+    }
+    return { data }
+  } catch (error) {
+    console.error(error)
+  }
+  return null
+}

--- a/client/src/features/authentication/by-google/ui/index.tsx
+++ b/client/src/features/authentication/by-google/ui/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { GoogleOutlined } from '@ant-design/icons'
+import { Tooltip, Button } from 'antd'
+import { Actions } from 'src/features/authentication/by-google/Actions'
+
+const GoogleAuthButton = () => {
+  const { signInWithGoogle } = Actions
+  return (
+    <Tooltip title="Login with Google account">
+      <Button onClick={signInWithGoogle} type="primary" shape="circle" icon={<GoogleOutlined />} />
+    </Tooltip>
+  )
+}
+
+export default GoogleAuthButton

--- a/client/src/features/authentication/index.ts
+++ b/client/src/features/authentication/index.ts
@@ -1,0 +1,4 @@
+export { default as LoginForm } from 'src/features/authentication/login/ui'
+export { default as SignInForm } from 'src/features/authentication/signin/ui'
+export { default as RegisterForm } from 'src/features/authentication/signup/ui'
+export { default as GoogleAuthButton } from 'src/features/authentication/by-google/ui'

--- a/client/src/features/authentication/invalidateAccessToken/model/listener.ts
+++ b/client/src/features/authentication/invalidateAccessToken/model/listener.ts
@@ -1,0 +1,22 @@
+import { createListenerMiddleware, type TypedStartListening } from '@reduxjs/toolkit'
+import { invalidateAccessToken } from 'src/shared/api'
+import { logoutThunk } from 'src/features/authentication/logout/model/logout'
+import { refreshTokenThunk } from 'src/features/authentication/refresh/model'
+import type { AppDispatch, RootState } from 'src/app/store/types'
+
+export const invalidateAccessTokenListener = createListenerMiddleware()
+
+// @see https://redux-toolkit.js.org/api/createListenerMiddleware#typescript-usage
+export type TypedListening = TypedStartListening<RootState, AppDispatch>
+
+export const startInvalidateAccessTokenListener = invalidateAccessTokenListener.startListening as TypedListening
+
+startInvalidateAccessTokenListener({
+  actionCreator: invalidateAccessToken,
+  effect: async (_, api) => {
+    // In the future here may be logic with refresh access token
+    // @see https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#preventing-multiple-unauthorized-errors
+    api.dispatch(logoutThunk())
+    api.dispatch(refreshTokenThunk())
+  }
+})

--- a/client/src/features/authentication/login/model/index.ts
+++ b/client/src/features/authentication/login/model/index.ts
@@ -1,0 +1,22 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { sessionApi } from 'src/entities/session/api/sessionApi'
+import { isFetchBaseQueryError } from 'src/shared/api/isFetchBaseQueryError'
+
+type Params = {
+  email: Email
+  password: string
+}
+
+export const loginThunk = createAsyncThunk('authentication/login', async (body: Params, { dispatch }) => {
+  try {
+    await dispatch(sessionApi.endpoints.login.initiate(body)).unwrap()
+  } catch (error) {
+    if (isFetchBaseQueryError(error)) {
+      if (typeof error.data === 'string') {
+        throw new Error(error.data)
+      }
+    }
+
+    throw new Error('Unknown error')
+  }
+})

--- a/client/src/features/authentication/login/ui/index.tsx
+++ b/client/src/features/authentication/login/ui/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { LockOutlined } from '@ant-design/icons'
+import { Button, Divider, Form, Input, Typography } from 'antd'
+import Link from 'antd/es/typography/Link'
+import { loginThunk } from 'src/features/authentication/login/model'
+import styles from './styles.module.scss'
+import type { AppDispatch, RootState } from 'src/app/store/types'
+
+const LoginForm: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+  const { Title, Paragraph, Text } = Typography
+  const email = useSelector((state: RootState) => state.session.email)
+  const onFinish = ({ password }: { password: string }) => {
+    dispatch(loginThunk({ email, password }))
+    navigate('/about', { replace: true })
+  }
+
+  useEffect(() => {
+    if (!email) navigate('/signin', { replace: true })
+  }, [])
+
+  return (
+    <Form name="initial_signin" className={styles.signInForm} initialValues={{ remember: true }} onFinish={onFinish}>
+      <Form.Item>
+        <Typography>
+          <Title>Type password</Title>
+          <Paragraph>
+            Please input your password from ATT for <Text strong>{email}</Text>
+          </Paragraph>
+        </Typography>
+      </Form.Item>
+      <Form.Item
+        label="Password"
+        name="password"
+        rules={[
+          {
+            required: true,
+            message: 'Please input your password.'
+          }
+        ]}
+      >
+        <Input prefix={<LockOutlined className="site-form-item-icon" />} type="password" placeholder="Password" />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" className="login-form-button">
+          Login
+        </Button>
+      </Form.Item>
+      <Form.Item>
+        <Divider plain>or</Divider>
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" className="login-form-button">
+          Get link to login
+        </Button>
+      </Form.Item>
+      <Form.Item>
+        <Link>Forget password?</Link>
+      </Form.Item>
+    </Form>
+  )
+}
+
+export default LoginForm

--- a/client/src/features/authentication/logout/index.ts
+++ b/client/src/features/authentication/logout/index.ts
@@ -1,0 +1,1 @@
+export { LogoutButton } from './ui'

--- a/client/src/features/authentication/logout/model/logout.ts
+++ b/client/src/features/authentication/logout/model/logout.ts
@@ -1,0 +1,10 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { clearSessionData } from 'src/entities/session/model/slice'
+import type { RootState } from 'src/app/store/types'
+
+export const logoutThunk = createAsyncThunk<void, void, { state: RootState }>(
+  'authentication/refresh',
+  async (_: unknown, { dispatch }) => {
+    dispatch(clearSessionData())
+  }
+)

--- a/client/src/features/authentication/logout/ui/index.tsx
+++ b/client/src/features/authentication/logout/ui/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { AppDispatch } from 'src/app/store/types'
+import { logoutThunk } from 'src/features/authentication/logout/model/logout'
+
+export const LogoutButton = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+  const onLogout = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation()
+    dispatch(logoutThunk())
+      .unwrap()
+      .finally(() => {
+        navigate('/')
+      })
+  }
+  return (
+    <a href="#" onClick={onLogout}>
+      Log out
+    </a>
+  )
+}

--- a/client/src/features/authentication/refresh/model/index.ts
+++ b/client/src/features/authentication/refresh/model/index.ts
@@ -1,0 +1,7 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { useRefreshQuery } from 'src/entities/session/api/sessionApi'
+import type { RootState } from 'src/app/store/types'
+
+export const refreshTokenThunk = createAsyncThunk<void, void, { state: RootState }>('authentication/logout', () => {
+  useRefreshQuery()
+})

--- a/client/src/features/authentication/signin/model/index.tsx
+++ b/client/src/features/authentication/signin/model/index.tsx
@@ -1,0 +1,15 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { supabase } from 'src/app/supabase'
+
+export const getRegisterStatusThunk = createAsyncThunk('authentication/getRegisterStatus', async (email: string) => {
+  try {
+    const { data, error } = await supabase.from('users_emails').select(`email`).eq('email', email)
+    if (error) {
+      throw new Error(error.message)
+    }
+    return data[0]
+  } catch (error) {
+    console.error(error)
+  }
+  return null
+})

--- a/client/src/features/authentication/signin/ui/index.tsx
+++ b/client/src/features/authentication/signin/ui/index.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react'
+import { LockOutlined } from '@ant-design/icons'
+import { Button, Divider, Form, Input } from 'antd'
+import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import GoogleAuthButton from 'src/features/authentication/by-google/ui'
+import { getRegisterStatusThunk } from 'src/features/authentication/signin/model'
+import { setUserEmail } from 'src/entities/session/model/slice'
+import styles from './styles.module.scss'
+import type { AppDispatch, RootState } from 'src/app/store/types'
+
+const SignInForm: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const [userEmail, setEmail] = useState('')
+  const navigate = useNavigate()
+  const { isAuthorized, isLoading, email } = useSelector((state: RootState) => state.session)
+  useEffect(() => {
+    console.log('userEmail && !isLoading, isAuthorized :', userEmail && !isLoading, isAuthorized)
+    console.log('userEmail, isLoading, isAuthorized :', userEmail, isLoading, isAuthorized)
+    if (userEmail && !isLoading) {
+      if (isAuthorized) {
+        navigate('/login', { replace: true })
+      } else {
+        navigate('/register', { replace: true })
+      }
+    }
+  }, [userEmail, isAuthorized, isLoading, email])
+
+  const onFinish = ({ initial_signin_email }: { initial_signin_email: string }) => {
+    dispatch(getRegisterStatusThunk(initial_signin_email))
+    dispatch(setUserEmail(initial_signin_email))
+    setEmail(initial_signin_email)
+  }
+
+  return (
+    <Form name="initial_signin" className={styles.signInForm} initialValues={{ remember: true }} onFinish={onFinish}>
+      <Form.Item
+        label="Email adress"
+        name="initial_signin_email"
+        rules={[
+          {
+            required: true,
+            message: 'Please input email.'
+          },
+          {
+            type: 'email',
+            message: 'Please enter a valid email'
+          }
+        ]}
+      >
+        <Input prefix={<LockOutlined className="site-form-item-icon" />} type="email" placeholder="Email" />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" className="login-form-button">
+          Continue with email
+        </Button>
+      </Form.Item>
+      <Form.Item>
+        <Divider plain>or</Divider>
+      </Form.Item>
+      <Form.Item>
+        <div className="authOptions">
+          <GoogleAuthButton />
+        </div>
+      </Form.Item>
+    </Form>
+  )
+}
+
+export default SignInForm

--- a/client/src/features/authentication/signin/ui/styles.module.scss
+++ b/client/src/features/authentication/signin/ui/styles.module.scss
@@ -1,0 +1,3 @@
+.signInForm {
+  
+}

--- a/client/src/features/authentication/signup/model/index.tsx
+++ b/client/src/features/authentication/signup/model/index.tsx
@@ -1,0 +1,26 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { sessionApi } from 'src/entities/session/api/sessionApi'
+import { isFetchBaseQueryError } from 'src/shared/api/isFetchBaseQueryError'
+import type { RootState } from 'src/app/store/types'
+
+type TSignUpProps = {
+  password: string
+}
+
+export const signupThunk = createAsyncThunk<any, TSignUpProps, { state: RootState }>(
+  'authentication/signup',
+  async ({ password }: TSignUpProps, { dispatch, getState }) => {
+    try {
+      const state = getState()
+      const { email } = state.session
+      await dispatch(sessionApi.endpoints.signup.initiate({ password, email })).unwrap()
+    } catch (error) {
+      if (isFetchBaseQueryError(error)) {
+        if (typeof error.data === 'string') {
+          throw new Error(error.data)
+        }
+      }
+      throw new Error('Unknown error')
+    }
+  }
+)

--- a/client/src/features/authentication/signup/ui/index.tsx
+++ b/client/src/features/authentication/signup/ui/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { LockOutlined } from '@ant-design/icons'
+import { Button, Form, Input, Typography } from 'antd'
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { signupThunk } from 'src/features/authentication/signup/model'
+import styles from './styles.module.scss'
+import type { AppDispatch } from 'src/app/store/types'
+
+const RegisterForm: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const { Title, Paragraph, Text } = Typography
+  const navigate = useNavigate()
+  const onFinish = ({ password }: { password: string }) => {
+    dispatch(signupThunk({ password }))
+    navigate('/about', { replace: true })
+  }
+  return (
+    <Form name="initial_signin" className={styles.signInForm} initialValues={{ remember: true }} onFinish={onFinish}>
+      <Form.Item>
+        <Typography>
+          <Title>
+            <Text strong>Choose security password</Text>
+          </Title>
+          <Paragraph>
+            The password must consist of uppercase and lowercase letters, numbers and symbols. The length is at least 10
+            characters.
+          </Paragraph>
+        </Typography>
+      </Form.Item>
+      <Form.Item
+        label="Password"
+        name="password"
+        rules={[
+          {
+            required: true,
+            message: 'Please input your password.'
+          },
+          {
+            min: 10
+          },
+          {
+            pattern: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])((?=.*\W)|(?=.*_))^[^ ]+$/
+          }
+        ]}
+        hasFeedback
+      >
+        <Input prefix={<LockOutlined className="site-form-item-icon" />} type="password" placeholder="Password" />
+      </Form.Item>
+      <Form.Item
+        label="Confirm password"
+        name="confirm_password"
+        rules={[
+          {
+            required: true,
+            message: 'Confirm your password.'
+          },
+          ({ getFieldValue }) => ({
+            validator(_, value) {
+              if (!value || getFieldValue('password') === value) {
+                return Promise.resolve()
+              }
+              // eslint-disable-next-line prefer-promise-reject-errors
+              return Promise.reject('Entered passwords do not match')
+            }
+          })
+        ]}
+      >
+        <Input prefix={<LockOutlined className="site-form-item-icon" />} type="password" placeholder="Password" />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" className="login-form-button">
+          Create account
+        </Button>
+      </Form.Item>
+    </Form>
+  )
+}
+
+export default RegisterForm

--- a/client/src/pages/About/index.tsx
+++ b/client/src/pages/About/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { Layout, Button } from 'antd'
+import { useTitle } from 'src/shared/lib/dom'
+import { Header } from 'src/widgets/header'
+import Section from './section'
+import styles from './styles.module.scss'
+
+const { Content } = Layout
+
+const HeroSection = () => (
+  <Section className={styles.hero} innerClassName={styles.heroContent}>
+    <h2>Букшеринг</h2>
+    <p>
+      Наш сервис позволяет людям обмениваться книгами. Владелец книги может отдать её сервису, чтобы предложить желающим
+      арендовать её.
+    </p>
+    <p>
+      Книгу можно отдать навсегда или на время. Желающие могут пользоваться книгой выбранный срок и платят за это
+      меньше, чем книга стоит в магазине.
+    </p>
+    <Button size="large">Попробовать</Button>
+  </Section>
+)
+
+const BenefitsSection = () => (
+  <Section className={styles.hero} innerClassName={styles.heroContent}>
+    <h2>Букшеринг</h2>
+    <p>
+      Наш сервис позволяет людям обмениваться книгами. Владелец книги может отдать её сервису, чтобы предложить желающим
+      арендовать её.
+    </p>
+    <p>
+      Книгу можно отдать навсегда или на время. Желающие могут пользоваться книгой выбранный срок и платят за это
+      меньше, чем книга стоит в магазине.
+    </p>
+    <Button size="large">Попробовать</Button>
+  </Section>
+)
+
+const FeaturesSection = () => (
+  <Section className={styles.hero} innerClassName={styles.heroContent}>
+    <h2>Букшеринг</h2>
+    <p>
+      Наш сервис позволяет людям обмениваться книгами. Владелец книги может отдать её сервису, чтобы предложить желающим
+      арендовать её.
+    </p>
+    <p>
+      Книгу можно отдать навсегда или на время. Желающие могут пользоваться книгой выбранный срок и платят за это
+      меньше, чем книга стоит в магазине.
+    </p>
+    <Button size="large">Попробовать</Button>
+  </Section>
+)
+
+const SocialSection = () => (
+  <Section className={styles.hero} innerClassName={styles.heroContent}>
+    <h2>Букшеринг</h2>
+    <p>
+      Наш сервис позволяет людям обмениваться книгами. Владелец книги может отдать её сервису, чтобы предложить желающим
+      арендовать её.
+    </p>
+    <p>
+      Книгу можно отдать навсегда или на время. Желающие могут пользоваться книгой выбранный срок и платят за это
+      меньше, чем книга стоит в магазине.
+    </p>
+    <Button size="large">Попробовать</Button>
+  </Section>
+)
+
+const About = () => {
+  useTitle('About Project')
+  return (
+    <Layout>
+      <Header />
+      <Content>
+        <HeroSection key="hero_0" />
+        <BenefitsSection key="hero_1" />
+        <FeaturesSection key="hero_2" />
+        <SocialSection key="hero_3" />
+      </Content>
+    </Layout>
+  )
+}
+
+export default About

--- a/client/src/pages/About/section/index.tsx
+++ b/client/src/pages/About/section/index.tsx
@@ -1,0 +1,20 @@
+import React, { PropsWithChildren } from 'react'
+import cn from 'classnames'
+import styles from './styles.module.scss'
+
+type Props = PropsWithChildren<{
+  id?: string
+  className?: string
+  innerClassName?: string
+  theme?: 'normal' | 'alt'
+}>
+
+const HomeSection = ({ id, children, className, innerClassName, theme = 'normal' }: Props) => {
+  return (
+    <section className={cn(styles.root, { [styles.rootAlt]: theme === 'alt' }, className)} id={id}>
+      <div className={cn(styles.content, innerClassName)}>{children}</div>
+    </section>
+  )
+}
+
+export default HomeSection

--- a/client/src/pages/About/section/styles.module.scss
+++ b/client/src/pages/About/section/styles.module.scss
@@ -1,0 +1,19 @@
+.root {
+  display: flex;
+  align-items: center;
+  height: 100vh;
+  padding: 40px 10%;
+  font-size: 20px;
+  background: #ffffff;
+
+  &Alt {
+    background: #f0f2f5;
+  }
+
+  h2 {
+    font-size: 30px;
+  }
+}
+
+.content {
+}

--- a/client/src/pages/About/styles.module.scss
+++ b/client/src/pages/About/styles.module.scss
@@ -1,0 +1,19 @@
+.hero {
+  background: url("./assets/bg_hero.jpg");
+
+  &Content {
+      color: #ffffff;
+
+      h2 {
+          color: #ffffff;
+      }
+  }
+}
+
+.benefits {
+  background: url("./assets/bg_books.png");
+}
+
+.features {
+  background: url("./assets/bg_laptop.jpg");
+}

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Layout } from 'antd'
+import { LoginForm } from 'src/features/authentication'
+import { Header } from 'src/widgets/header'
+
+const Login = () => {
+  return (
+    <Layout>
+      <Header />
+      <Layout.Content>
+        <LoginForm />
+      </Layout.Content>
+    </Layout>
+  )
+}
+
+export default Login

--- a/client/src/pages/Register/index.tsx
+++ b/client/src/pages/Register/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Layout } from 'antd'
+import { RegisterForm } from 'src/features/authentication'
+import { Header } from 'src/widgets/header'
+
+const Register = () => {
+  return (
+    <Layout>
+      <Header />
+      <Layout.Content>
+        <RegisterForm />
+      </Layout.Content>
+    </Layout>
+  )
+}
+
+export default Register

--- a/client/src/pages/Signin/index.tsx
+++ b/client/src/pages/Signin/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Layout } from 'antd'
+import { SignInForm } from 'src/features/authentication'
+import { Header } from 'src/widgets/header'
+
+const Signin = () => {
+  return (
+    <Layout>
+      <Header />
+      <Layout.Content>
+        <SignInForm />
+      </Layout.Content>
+    </Layout>
+  )
+}
+
+export default Signin

--- a/client/src/shared/api/baseApi.ts
+++ b/client/src/shared/api/baseApi.ts
@@ -1,0 +1,9 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { baseQueryWithReauth } from 'src/shared/api/baseQueryWithReauth'
+
+export const baseApi = createApi({
+  tagTypes: [],
+  reducerPath: 'api',
+  baseQuery: baseQueryWithReauth,
+  endpoints: () => ({})
+})

--- a/client/src/shared/api/baseQuery.ts
+++ b/client/src/shared/api/baseQuery.ts
@@ -1,0 +1,16 @@
+import { fetchBaseQuery } from '@reduxjs/toolkit/dist/query'
+import { config } from 'src/shared/config'
+import type { RootState } from 'src/app/store/types'
+
+export const baseQuery = fetchBaseQuery({
+  baseUrl: config.API_ENDPOINT,
+  prepareHeaders: (headers, { getState }) => {
+    const { accessToken } = (getState() as RootState).session
+
+    if (accessToken) {
+      headers.set('Authorization', `Bearer ${accessToken}`)
+      headers.set('credentials', 'same origin')
+    }
+    return headers
+  }
+})

--- a/client/src/shared/api/baseQueryWithReauth.ts
+++ b/client/src/shared/api/baseQueryWithReauth.ts
@@ -1,0 +1,18 @@
+import { BaseQueryApi, FetchArgs } from '@reduxjs/toolkit/dist/query'
+import { baseQuery } from 'src/shared/api/baseQuery'
+import { invalidateAccessToken } from 'src/shared/api/invalidateTokenEvent'
+
+const AUTH_ERROR_CODES = new Set([401])
+
+export async function baseQueryWithReauth(
+  args: string | FetchArgs,
+  api: BaseQueryApi,
+  extraOptions: Record<string, unknown>
+) {
+  const result = await baseQuery(args, api, extraOptions)
+
+  if (typeof result.error?.status === 'number' && AUTH_ERROR_CODES.has(result.error.status)) {
+    api.dispatch(invalidateAccessToken())
+  }
+  return result
+}

--- a/client/src/shared/api/index.ts
+++ b/client/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+export { baseApi } from './baseApi'
+export { invalidateAccessToken } from './invalidateTokenEvent'

--- a/client/src/shared/api/invalidateTokenEvent.ts
+++ b/client/src/shared/api/invalidateTokenEvent.ts
@@ -1,0 +1,3 @@
+import { createAction } from '@reduxjs/toolkit'
+
+export const invalidateAccessToken = createAction('session/invalidateAccessToken')

--- a/client/src/shared/api/isFetchBaseQueryError.ts
+++ b/client/src/shared/api/isFetchBaseQueryError.ts
@@ -1,0 +1,5 @@
+import { type FetchBaseQueryError } from '@reduxjs/toolkit/dist/query'
+
+export function isFetchBaseQueryError(error: unknown): error is FetchBaseQueryError {
+  return typeof error === 'object' && error != null && 'status' in error
+}

--- a/client/src/shared/config.ts
+++ b/client/src/shared/config.ts
@@ -1,0 +1,26 @@
+/**
+ * Модуль инициализации env-переменных
+ * @remark Если не найдено значение хоть одной переменной,
+ * Приложение сразу выбросит ошибку, при инициализации модуля
+ * @module
+ */
+
+/**
+ * Получение env-переменной
+ * @throwable
+ */
+
+// export const getEnvVar = (key: string) => {
+//   if (process.env[key] === undefined) {
+//     throw new Error(`Env variable ${key} is required`)
+//   }
+//   return process.env[key] || ''
+// }
+
+// export const METRIKA_ID = Number(getEnvVar('REACT_APP_METRIKA_ID'))
+
+export const config = {
+  API_ENDPOINT: import.meta.env.VITE_SUPABASE_URL,
+  API_KEY: import.meta.env.VITE_SUPABASE_KEY,
+  PREFIX: 'ATT'
+} as const

--- a/client/src/shared/lib/browser/index.ts
+++ b/client/src/shared/lib/browser/index.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const keyLS = `${PREFIX}:${key}`
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(keyLS)
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      // If error also return initialValue
+      // console.log(error);
+      return initialValue
+    }
+  })
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      // Save state
+      setStoredValue(valueToStore)
+      // Save to local storage
+      window.localStorage.setItem(keyLS, JSON.stringify(valueToStore))
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      // console.log(error);
+    }
+  }
+  return [storedValue, setValue] as const
+}

--- a/client/src/shared/lib/dom/index.ts
+++ b/client/src/shared/lib/dom/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @hook Set page title
+ */
+
+import { useEffect } from 'react'
+
+export const useTitle = (title: string) => {
+  useEffect(() => {
+    document.title = title
+  }, [title])
+}

--- a/client/src/shared/lib/hooks/index.ts
+++ b/client/src/shared/lib/hooks/index.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export const useRedirectOn = (value: string, redirectTo: string) => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (value) {
+      navigate(redirectTo)
+    }
+  }, [value, redirectTo])
+}

--- a/client/src/widgets/header/index.tsx
+++ b/client/src/widgets/header/index.tsx
@@ -1,0 +1,1 @@
+export { default as Header } from './ui'

--- a/client/src/widgets/header/ui/index.tsx
+++ b/client/src/widgets/header/ui/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Layout, Badge } from 'antd'
+import cn from 'classnames'
+import { Link } from 'react-router-dom'
+import { NotificationOutlined } from '@ant-design/icons'
+import { useAuth } from 'src/entities/viewer/model/selectors'
+import { LogoutButton } from 'src/features/authentication/logout/ui'
+import styles from './styles.module.scss'
+
+type THeader = {
+  className?: string
+} & React.HTMLAttributes<HTMLElement>
+
+const actions = [
+  {
+    id: 'project_news' as const,
+    label: 'Project news',
+    Icon: NotificationOutlined,
+    url: '/project_news',
+    disabled: false,
+    hidden: false
+  }
+]
+
+type ActionId = (typeof actions)[number]['id']
+
+const count: Partial<Record<ActionId, number>> = {
+  project_news: 0
+}
+const Header = ({ className }: THeader) => {
+  const { isAuth } = useAuth()
+  return (
+    <Layout.Header className={cn(styles.root, className)}>
+      <Link to="/" className={styles.logo}>
+        Сайт
+      </Link>
+      <div className={styles.search}>Поиск</div>
+      <div className={styles.toolbar}>
+        {actions.map(({ id, label, Icon, url, disabled }) => (
+          <Link
+            key={label}
+            to={url}
+            className={cn(styles.toolbarAction, {
+              [styles.toolbarActionDisabled]: disabled
+            })}
+          >
+            <span className={styles.toolbarActionIcon}>
+              <Badge count={count[id]} style={{ backgroundColor: '#108ee9' }}>
+                <Icon style={{ fontSize: 24 }} />
+              </Badge>
+            </span>
+            <span>{label}</span>
+          </Link>
+        ))}
+      </div>
+      <div className={styles.authorization}>{!isAuth ? <Link to="/signin">Sign in</Link> : <LogoutButton />}</div>
+    </Layout.Header>
+  )
+}
+
+export default Header

--- a/client/src/widgets/header/ui/styles.module.scss
+++ b/client/src/widgets/header/ui/styles.module.scss
@@ -1,0 +1,27 @@
+.root {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    &Action {
+      display: flex;
+      flex-direction: column;
+      margin: 0 10px;
+      line-height: 16px;
+  
+      &Disabled {
+          pointer-events: none;
+          opacity: 0.5;
+      }
+  
+      &Icon {
+          text-align: center;
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
1. Add basic authorization features (login, logout, signin, signup) based on supabase sevice. Add header with about page for test purposes.